### PR TITLE
Add query validation and tests

### DIFF
--- a/server/__tests__/search.test.js
+++ b/server/__tests__/search.test.js
@@ -1,0 +1,10 @@
+const request = require('supertest');
+const app = require('../index');
+
+describe('POST /api/search', () => {
+  it('returns 400 when query is empty', async () => {
+    const res = await request(app).post('/api/search').send({ query: '' });
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('error');
+  });
+});

--- a/server/index.js
+++ b/server/index.js
@@ -23,6 +23,9 @@ const openai = new OpenAI({
 
 app.post('/api/search', async (req, res) => {
   const { query } = req.body;
+  if (typeof query !== 'string' || query.trim() === '') {
+    return res.status(400).json({ error: 'Query must be a non-empty string' });
+  }
   console.log("🔍 User description:", query);
 
   try {
@@ -71,6 +74,10 @@ app.post('/api/search', async (req, res) => {
   }
 });
 
-app.listen(port, () => {
-  console.log(`🚀 AI Movie Search backend running at http://localhost:${port}`);
-});
+if (require.main === module) {
+  app.listen(port, () => {
+    console.log(`🚀 AI Movie Search backend running at http://localhost:${port}`);
+  });
+}
+
+module.exports = app;

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
@@ -14,5 +14,9 @@
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "openai": "^4.98.0"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
   }
 }


### PR DESCRIPTION
## Summary
- validate the search query is a non-empty string
- export Express app for testing
- add Jest and Supertest for backend tests
- cover invalid query with a new test

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685cb210c11c832caf824408a9b0ac6a