### PR TITLE
Show assistant message on fetch error

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -30,9 +30,20 @@ function App() {
         body: JSON.stringify(body)
       })
       const data = await res.json()
-      if (data.message) setMessages([...newMessages, data.message])
+      if (data.message) {
+        setMessages([...newMessages, data.message])
+      } else if (data.error) {
+        setMessages([
+          ...newMessages,
+          { role: 'assistant', content: 'Sorry, something went wrong' },
+        ])
+      }
     } catch (err) {
       console.error('Chat error', err)
+      setMessages([
+        ...newMessages,
+        { role: 'assistant', content: 'Sorry, something went wrong' },
+      ])
     } finally {
       setLoading(false)
       setFile(null)


### PR DESCRIPTION
## Summary
- show an assistant message if the `/api/chat` call fails or returns an error

## Testing
- `npm run lint` in `client`
- `npx jest` in `server`


------
https://chatgpt.com/codex/tasks/task_e_685ce7b78010832c8f36952600da2204