### PR TITLE
Adjust body parser limit

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -23,7 +23,8 @@ app.use(cors({
   allowedHeaders: ['Content-Type']
 }));
 
-app.use(express.json());
+// allow larger JSON payloads for image uploads
+app.use(express.json({ limit: '30mb' }));
 
 const openai = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY,


### PR DESCRIPTION
## Summary
- allow larger request bodies in `server/index.js`

## Testing
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_685ce79f96d4832cb10828845ecb6495